### PR TITLE
Fix ordering of children

### DIFF
--- a/lib/tree/cities_worker.ex
+++ b/lib/tree/cities_worker.ex
@@ -5,6 +5,7 @@ defmodule Genealogist.CitiesWorker do
 
   def init(:ok) do
     {:ok, _} = Supervisor.start_child(Genealogist.CitiesChildrenSupervisor, ["Melbourne"])
+    {:ok, _} = Supervisor.start_child(Genealogist.CitiesChildrenSupervisor, ["William Creek"])
     {:ok, :nil_state}
   end
 end

--- a/test/builder_test.exs
+++ b/test/builder_test.exs
@@ -22,12 +22,10 @@ defmodule BuilderTest do
           :supervisor,
           [Genealogist.CitiesSupervisor],
           [
+            {:worker, [Genealogist.CitiesWorker]},
             {:supervisor, [Genealogist.CitiesChildrenSupervisor],
-             [
-               {:worker, ["Untitled"]},
-             ]
+             [{:worker, ["Untitled"]},{:worker, ["Untitled"]}]
             },
-            {:worker, [Genealogist.CitiesWorker]}
           ]
         }
       ]
@@ -46,12 +44,13 @@ defmodule BuilderTest do
               :supervisor,
               [Genealogist.CitiesSupervisor],
               [
+                {:worker, [Genealogist.CitiesWorker]},
                 {:supervisor, [Genealogist.CitiesChildrenSupervisor],
                  [
                    {:worker, [{:registry, Genealogist.Registry, "Cities!Melbourne"}]},
+                   {:worker, [{:registry, Genealogist.Registry, "Cities!William Creek"}]},
                  ]
                 },
-                {:worker, [Genealogist.CitiesWorker]}
               ]
             }
           ]


### PR DESCRIPTION
Because of the way I was recursing children were coming out in reverse
order at some levels of the supervision tree. Instead of adding to
lists which naturally reverses lists and was making things harder to
reason about, I switched to using `Enum.map/2` to iterate while
keeping order